### PR TITLE
feat: Use BuildConstants template to manage version code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'WaterFun.WaterWood'
-version = '1.0'
+version = '1.1.3'
 
 repositories {
     mavenCentral()

--- a/src/main/java/site/hjfunny/velochatx/VeloChatX.java
+++ b/src/main/java/site/hjfunny/velochatx/VeloChatX.java
@@ -20,7 +20,7 @@ import site.hjfunny.velochatx.methods.Methods;
 @Plugin(
         id = "velochatx",
         name = "VeloChatX",
-        version = "1.0",
+        version = BuildConstants.VERSION,
         authors = "Waterwood")
 public class VeloChatX extends VelocityPlugin {
     private final ProxyServer server;
@@ -39,7 +39,7 @@ public class VeloChatX extends VelocityPlugin {
         for(String str : LineFontGenerator.parseLineText("velochatx")){
             getLogger().info(Colors.parseColor("§6%s§r").formatted(str));
         }
-        getLogger().info(Colors.parseColor("VeloChatX §7V%s §7Author:§rWaterwood".formatted(getPluginInfo("version"))));
+        getLogger().info(Colors.parseColor("VeloChatX §7V%s §7Author:§rWaterwood".formatted(BuildConstants.VERSION)));
         long start = System.currentTimeMillis();
         Instance = this;
         this.loadConfig();

--- a/src/main/java/site/hjfunny/velochatx/commands/ControlCommands.java
+++ b/src/main/java/site/hjfunny/velochatx/commands/ControlCommands.java
@@ -9,6 +9,7 @@ import org.waterwood.common.Colors;
 import org.waterwood.plugin.WaterPlugin;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
+import site.hjfunny.velochatx.BuildConstants;
 import site.hjfunny.velochatx.PlayerAttribution;
 import site.hjfunny.velochatx.VeloChatX;
 import site.hjfunny.velochatx.events.PlayerEvents;
@@ -59,7 +60,7 @@ public class ControlCommands extends VelocitySimpleCommand implements SimpleComm
             String language = sourcePlayer.getEffectiveLocale().getLanguage();
                 if (args[0].equalsIgnoreCase("help")) {
                     source.sendMessage(Component.text("---===\n§1VeloChatX§r  §bv%s§r  §2By:%s§r \n===---"
-                            .formatted(WaterPlugin.getPluginInfo("version"), WaterPlugin.getPluginInfo("author"))));
+                            .formatted(BuildConstants.VERSION, WaterPlugin.getPluginInfo("author"))));
                     for (String cmd : subCmds) {
                         source.sendMessage(Component.text(getMessage(cmd + "-command-format-message", language)));
                     }
@@ -115,7 +116,7 @@ public class ControlCommands extends VelocitySimpleCommand implements SimpleComm
         }else{
             if (args[0].equalsIgnoreCase("help")) { //help command
                 source.sendMessage(Component.text(Colors.parseColor("---------------------------\n§1VeloChatX§r  §bv%s§r  §2By:%s§r\n---------------------------"
-                        .formatted(WaterPlugin.getPluginInfo("version"), WaterPlugin.getPluginInfo("author")))));
+                        .formatted(BuildConstants.VERSION, WaterPlugin.getPluginInfo("author")))));
                 for (String cmd : subCmds) {
                     source.sendMessage(Component.text(Colors.parseColor(getMessage(cmd + "-command-format-message"))));
                 }

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,4 @@
 name: VeloChatX
-version: 1.1.3
 author: waterwood
 main: site.hjfunny.velochatx.VeloChatX
 description: A plugin for velocity that all backend servers cross server chat

--- a/src/main/templates/site/hjfunny/velochatx/BuildConstants.java
+++ b/src/main/templates/site/hjfunny/velochatx/BuildConstants.java
@@ -1,0 +1,7 @@
+package site.hjfunny.velochatx;
+
+// The constants are replaced before compilation
+public class BuildConstants {
+
+    public static final String VERSION = "${version}";
+}


### PR DESCRIPTION
The version code is now read using `BuildConstants.VERSION` from `site.hjfunny.velochatx.BuildConstants` and is synchronised with `build.gradle`.

Modify the version code from `build.gradle` from now on.

```diff
-WaterPlugin.getPluginInfo("version")
+BuildConstants.VERSION
```